### PR TITLE
email.message_from_string expects a str (py2) not unicode

### DIFF
--- a/modoboa_amavis/factories.py
+++ b/modoboa_amavis/factories.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Amavis factories."""
 
 from __future__ import unicode_literals
@@ -158,6 +159,7 @@ def create_quarantined_msg(rcpt, sender, rs, body, **kwargs):
 def create_spam(rcpt, sender="spam@evil.corp", rs=" "):
     """Create a spam."""
     body = SPAM_BODY.format(rcpt=rcpt, sender=sender)
+    body += 'fóó bár'
     return create_quarantined_msg(
         rcpt, sender, rs, body, bspam_level=999.0, content="S")
 

--- a/modoboa_amavis/sql_email.py
+++ b/modoboa_amavis/sql_email.py
@@ -6,6 +6,7 @@ An email representation based on a database record.
 from __future__ import unicode_literals
 
 from django.template.loader import render_to_string
+from django.utils.encoding import smart_str
 
 from modoboa.lib.email_utils import Email
 
@@ -43,7 +44,7 @@ class SQLemail(Email):
 
         if self._msg is None:
             mail_text = get_connector().get_mail_content(self.mailid)
-            self._msg = email.message_from_string(mail_text)
+            self._msg = email.message_from_string(smart_str(mail_text))
             self._parse(self._msg)
         return self._msg
 

--- a/modoboa_amavis/views.py
+++ b/modoboa_amavis/views.py
@@ -12,7 +12,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render
 from django.template import loader, Context
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_text, smart_str
 from django.utils.translation import ugettext as _, ungettext
 
 from django.contrib.auth.decorators import login_required
@@ -183,7 +183,7 @@ def viewmail(request, mail_id):
 def viewheaders(request, mail_id):
     """Display message headers."""
     content = get_connector().get_mail_content(mail_id)
-    msg = email.message_from_string(content)
+    msg = email.message_from_string(smart_str(content))
     headers = []
     for name, value in msg.items():
         headers += [(name, value)]


### PR DESCRIPTION
If an email message containing unicode characters is passed to python 2 a UnicodeEncodeError exception is generated, to fix this the email message is converted to bytes. This issue doesn't affect python 3 as python 3 treats all strings as unicode.

