### PR TITLE
remove unnecessary parameter, links defaults to 0 and has no effect when mformat="plain"

### DIFF
--- a/modoboa_amavis/views.py
+++ b/modoboa_amavis/views.py
@@ -135,7 +135,7 @@ def index(request):
 
 
 def getmailcontent_selfservice(request, mail_id):
-    mail = SQLemail(mail_id, mformat="plain", links="0")
+    mail = SQLemail(mail_id, mformat="plain")
     return render(request, "common/viewmail.html", {
         "headers": mail.render_headers(),
         "mailbody": mail.body
@@ -144,7 +144,7 @@ def getmailcontent_selfservice(request, mail_id):
 
 @selfservice(getmailcontent_selfservice)
 def getmailcontent(request, mail_id):
-    mail = SQLemail(mail_id, mformat="plain", links="0")
+    mail = SQLemail(mail_id, mformat="plain")
     return render(request, "common/viewmail.html", {
         "headers": mail.render_headers(),
         "mailbody": mail.body


### PR DESCRIPTION
On a side note this should have been links=0 (integer), as using "0" (string)
results in the complete opposite when used in a boolean comparison.

if "0": <= True
if 0:   <= False