### PR TITLE
convert html quarantined message to plain text if a plain text version isn't available

### DIFF
--- a/modoboa_amavis/sql_connector.py
+++ b/modoboa_amavis/sql_connector.py
@@ -215,7 +215,7 @@ class SQLconnector(object):
 
     def get_mail_content(self, mailid):
         """Retrieve the content of a message."""
-        content = b"".join([
+        content = smart_bytes("").join([
             smart_bytes(qmail.mail_text)
             for qmail in Quarantine.objects.filter(
                     mail=smart_bytes(mailid))

--- a/modoboa_amavis/sql_email.py
+++ b/modoboa_amavis/sql_email.py
@@ -1,14 +1,12 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
+
 """
 An email representation based on a database record.
 """
 
 from __future__ import unicode_literals
 
-import email
-
 from django.template.loader import render_to_string
-from django.utils.encoding import smart_str
 
 from modoboa.lib.email_utils import Email
 
@@ -21,34 +19,28 @@ class SQLemail(Email):
 
     def __init__(self, *args, **kwargs):
         super(SQLemail, self).__init__(*args, **kwargs)
-        fields = ["From", "To", "Cc", "Date", "Subject"]
-        for field in fields:
-            self.headers += [
-                {"name": field, "value": self.get_header(self.msg, field)}
-            ]
-            setattr(self, field, self.msg[field])
-        qreason = self.get_header(self.msg, "X-Amavis-Alert")
         self.qtype = ""
         self.qreason = ""
-        if qreason != "":
+
+        qreason = self.msg["X-Amavis-Alert"]
+        if qreason:
             if ',' in qreason:
-                self.qtype, self.qreason = qreason.split(',', 1)
+                self.qtype, qreason = qreason.split(',', 1)
             elif qreason.startswith("BAD HEADER SECTION "):
                 # Workaround for amavis <= 2.8.0 :p
                 self.qtype = "BAD HEADER SECTION"
-                self.qreason = qreason[19:]
+                qreason = qreason[19:]
 
-    @property
-    def msg(self):
-        """Get message's content."""
-        if self._msg is None:
-            mail_text = get_connector().get_mail_content(self.mailid)
-            self._msg = email.message_from_string(smart_str(mail_text))
-            self._parse(self._msg)
-        return self._msg
+            qreason = " ".join([x.strip() for x in qreason.splitlines()])
+            self.qreason = qreason
+
+    def _fetch_message(self):
+        return get_connector().get_mail_content(self.mailid)
 
     def render_headers(self, **kwargs):
-        return render_to_string("modoboa_amavis/mailheaders.html", {
-            "qtype": self.qtype, "qreason": self.qreason,
+        context = {
+            "qtype": self.qtype,
+            "qreason": self.qreason,
             "headers": self.headers,
-        })
+        }
+        return render_to_string("modoboa_amavis/mailheaders.html", context)

--- a/modoboa_amavis/tests/sample_messages/quarantined-input.txt
+++ b/modoboa_amavis/tests/sample_messages/quarantined-input.txt
@@ -1,0 +1,80 @@
+X-Envelope-From: <it-edu@evil.example.net>
+X-Envelope-To: <me@example.net>
+X-Envelope-To-Blocked: <me@example.net>
+X-Quarantine-ID: <nZkKQ_MUuyil>
+X-Amavis-Alert: BAD HEADER SECTION, Non-encoded non-ASCII data (and not UTF-8)
+	(char 85 hex): Subject: I think I saw you in my dreams\x{85}
+X-Spam-Flag: YES
+X-Spam-Score: 8.178
+X-Spam-Level: ********
+X-Spam-Status: Yes, score=8.178 tag=-999 tag2=3.9 kill=5
+	tests=[HEADER_FROM_DIFFERENT_DOMAINS=0.25, HTML_IMAGE_ONLY_28=0.726,
+	HTML_MESSAGE=0.001, MIME_HTML_ONLY=1.105, RCVD_IN_MSPIKE_H2=-0.001,
+	TVD_PH_BODY_ACCOUNTS_PRE=0.001, T_REMOTE_IMAGE=0.01,
+	T_RP_MATCHES_RCVD=-0.01, URIBL_BLACK=1.7, URIBL_DBL_ABUSE_SPAM=2,
+	URI_WPADMIN=2.396] autolearn=no autolearn_force=no
+Received: from mail.example.net ([127.0.0.1])
+	by mail.example.net (mail.example.net [127.0.0.1]) (amavisd-new, port 10024)
+	with LMTP id nZkKQ_MUuyil for <me@example.net>;
+	Sat, 16 Dec 2017 13:09:49 +0000 (GMT)
+Received: from evil.example.net (mail.evil.example.net [10.0.0.1])
+	by mail.example.net (Postfix) with ESMTPS id 62B2E1AF12D
+	for <me@example.net>; Sat, 16 Dec 2017 13:09:49 +0000 (GMT)
+Received: from it-edu by evil.example.net with local (Exim 4.82)
+	(envelope-from <it-edu@evil.example.net>)
+	id 1eQCDr-0005NE-IT
+	for me@example.net; Sat, 16 Dec 2017 16:09:47 +0300
+To: me@example.net
+Subject: =?UTF-8?Q?Account_Suspension_Notification_=21?=
+X-PHP-Originating-Script: 520:maill.php
+Date: Sat, 16 Dec 2017 16:09:47 +0300
+From: Notice <Notice@fake.example.net>
+Reply-To: Notice@fake.example.net
+Message-ID: <6619a5295cefcf484a58944fc280eb90@evil.example.net>
+X-Priority: 1
+X-Mailer: PHPMailer 5.2.10 (https://github.com/PHPMailer/PHPMailer/)
+MIME-Version: 1.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Transfer-Encoding: 8bit
+
+<!DOCTYPE html>
+<html>
+<HEAD><STYLE>
+.cssage P
+{
+margin:0px;
+padding:0px
+}
+body.cssage
+{
+font-size: 12pt;
+font-family:Calibri
+}
+</STYLE>
+
+</HEAD>
+<BODY class="cssage">
+<DIV dir="ltr"><FONT size=2 face="Arial, Helvetica, sans-serif"></FONT><BR>
+<DIV>
+<DIV>
+<TABLE style="FONT-FAMILY: 'Times New Roman'" border=0 cellSpacing=0 cellPadding=0 width=600 align="center">
+<TR class=header>
+<TD vAlign=bottom><SPAN style="FONT-FAMILY: 'Trebuchet MS', Arial, Helvetica, sans-serif; COLOR: rgb(159,159,159); FONT-SIZE: 12px" >This is an automated email, please do not reply</SPAN></TD>
+<TD align=right><IMG style="WIDTH: 215px; HEIGHT: 66px" alt="" src="http://im55.gulfup.com/oLrUdE.jpg"></TD></TR>
+<TR >
+<TD height=14 vAlign=bottom colSpan=2><IMG src="https://www.payza.com/emails/images/bar.png" width="100%" height=3></TD></TR>
+<TR>
+<TD colSpan=2>
+<H1 style="PADDING-BOTTOM: 0px; PADDING-LEFT: 0px; PADDING-RIGHT: 0px; FONT-FAMILY: 'Trebuchet MS', Arial, Helvetica, sans-serif; COLOR: rgb(189,151,0); FONT-SIZE: 24px; FONT-WEIGHT: normal; PADDING-TOP: 10px">Dear Client</H1>
+<P style="LINE-HEIGHT: 21px; FONT-FAMILY: 'Trebuchet MS', Arial, Helvetica, sans-serif; COLOR: rgb(84,84,84); FONT-SIZE: 14px">We've noticed that some of your account information appears to be missing or incorrect
+We need to verify your account information in order to continue using your Apple ID, Please Verify your account information by clicking on the link below<BR><BR><B><A style="COLOR: rgb(27,144,234)" href="http://chiikulab.com/wp-admin/images/Update/Apple2018%20V2.1/
+" target=_blank>Click here to Verify your ID</A></B></P></TD></TR>
+<TR>
+<TD colSpan=2>
+<DIV><SPAN style="FONT-FAMILY: 'Trebuchet MS', Arial, Helvetica, sans-serif; COLOR: rgb(51,102,204); FONT-SIZE: 15px" ></SPAN><BR></DIV><br><SPAN style="FONT-FAMILY: 'Trebuchet MS', Arial, Helvetica, sans-serif; COLOR: rgb(202,162,0); FONT-SIZE: 17px" class=ecxthanks>Thanks for choosing Apple,</SPAN><BR style="COLOR: rgb(202,162,0)"><SPAN style="FONT-FAMILY: 'Trebuchet MS', Arial, Helvetica, sans-serif; COLOR: rgb(202,162,0); FONT-SIZE: 15px" >Apple Team</SPAN></TD></TR>
+<TR >
+<TD height=14 vAlign=bottom colSpan=2><IMG src="https://www.payza.com/emails/images/bar.png" width="100%" height=3></TD></TR>
+<TR>
+<TD colSpan=2>
+<P style="PADDING-BOTTOM: 0px; PADDING-LEFT: 0px; PADDING-RIGHT: 0px; FONT-FAMILY: 'Trebuchet MS', Arial, Helvetica, sans-serif; COLOR: rgb(84,84,84); FONT-SIZE: 12px; PADDING-TOP: 10px" >&copy; 2017 Apple. All rights reserved.</P>
+<P style="FONT-FAMILY: 'Trebuchet MS', Arial, Helvetica, sans-serif; COLOR: rgb(186,148,0); FONT-SIZE: 11px">Email ID: 163327</P></TD></TR></TABLE></DIV></DIV></DIV></BODY></html>

--- a/modoboa_amavis/tests/sample_messages/quarantined-output-plain_nolinks.txt
+++ b/modoboa_amavis/tests/sample_messages/quarantined-output-plain_nolinks.txt
@@ -1,0 +1,17 @@
+<pre>This is an automated email, please do not reply  
+
+# Dear Client
+
+We&#39;ve noticed that some of your account information appears to be missing or
+incorrect We need to verify your account information in order to continue
+using your Apple ID, Please Verify your account information by clicking on the
+link below  
+
+ **Click here to Verify your ID**  
+
+Thanks for choosing Apple,  
+Apple Team  
+
+(C) 2017 Apple. All rights reserved.
+
+Email ID: 163327</pre>

--- a/modoboa_amavis/tests/test_sql_email.py
+++ b/modoboa_amavis/tests/test_sql_email.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for sql_email."""
+
+from __future__ import unicode_literals
+
+import os
+
+from django.test import TestCase
+from django.utils.encoding import smart_bytes, smart_text
+
+from ..sql_email import SQLemail
+
+SAMPLES_DIR = os.path.realpath(
+    os.path.join(os.path.dirname(__file__), "sample_messages"))
+
+
+class EmailTestImplementation(SQLemail):
+
+    def _fetch_message(self):
+        message_path = os.path.join(SAMPLES_DIR, "%s-input.txt" % self.mailid)
+        assert os.path.isfile(message_path), "%s does not exist." % message_path
+
+        with open(message_path, "rb") as fp:
+            mail_text = smart_bytes(fp.read())
+
+        return mail_text
+
+
+class EmailTests(TestCase):
+    """Tests for modoboa_amavis.sql_email.SQLEmail
+
+    When writing new sample messages use the following naming convention for
+    the sample files stored in sample_messages:
+
+    input:  {message_id}-input.txt
+    output: {message_id}-output-{dformat}_{no,}links.txt
+    """
+
+    def _get_expected_output(self, message_id, **kwargs):
+        ext = kwargs["dformat"] if "dformat" in kwargs else "plain"
+        ext += "_links" if "links" in kwargs and kwargs["links"] else "_nolinks"
+        message_path = os.path.join(SAMPLES_DIR,
+                                    "%s-output-%s.txt" % (message_id, ext))
+        assert os.path.isfile(message_path), "%s does not exist." % message_path
+
+        with open(message_path, "rb") as fp:
+            # output should always be unicode (py2) or str (py3)
+            mail_text = smart_text(fp.read())
+
+        return mail_text
+
+    def _test_email(self, message_id, **kwargs):
+        """Boiler plate code for testing e-mails."""
+        expected_output = self._get_expected_output(message_id, **kwargs)
+        output = EmailTestImplementation(message_id, **kwargs).body
+        self.assertEqual(output, expected_output)
+
+    def test_amavis_aleart_header(self):
+        email = EmailTestImplementation("quarantined")
+        self.assertEqual(email.qtype, "BAD HEADER SECTION")
+        self.assertEqual(email.qreason,
+                         "Non-encoded non-ASCII data (and not UTF-8) (char 85 "
+                         "hex): Subject: I think I saw you in my dreams\\x{85}")
+
+    def test_email_multipart_with_no_text(self):
+        """for a multipart message without a text/plain part convert the
+           text/html to text/plain"""
+        self._test_email("quarantined")

--- a/modoboa_amavis/views.py
+++ b/modoboa_amavis/views.py
@@ -4,15 +4,13 @@ Amavis quarantine views.
 """
 from __future__ import unicode_literals
 
-import email
-
 import six
 
 from django.urls import reverse
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render
 from django.template import loader
-from django.utils.encoding import smart_text, smart_str
+from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _, ungettext
 
 from django.contrib.auth.decorators import login_required
@@ -135,7 +133,7 @@ def index(request):
 
 
 def getmailcontent_selfservice(request, mail_id):
-    mail = SQLemail(mail_id, mformat="plain")
+    mail = SQLemail(mail_id, dformat="plain")
     return render(request, "common/viewmail.html", {
         "headers": mail.render_headers(),
         "mailbody": mail.body
@@ -144,7 +142,7 @@ def getmailcontent_selfservice(request, mail_id):
 
 @selfservice(getmailcontent_selfservice)
 def getmailcontent(request, mail_id):
-    mail = SQLemail(mail_id, mformat="plain")
+    mail = SQLemail(mail_id, dformat="plain")
     return render(request, "common/viewmail.html", {
         "headers": mail.render_headers(),
         "mailbody": mail.body
@@ -187,14 +185,14 @@ def viewmail(request, mail_id):
 @login_required
 def viewheaders(request, mail_id):
     """Display message headers."""
-    content = get_connector().get_mail_content(mail_id)
-    msg = email.message_from_string(smart_str(content))
+    email = SQLemail(mail_id)
     headers = []
-    for name, value in msg.items():
-        headers += [(name, value)]
-    return render(request, 'modoboa_amavis/viewheader.html', {
+    for name in email.msg.keys():
+        headers.append((name, email.get_header(email.msg, name)))
+    context = {
         "headers": headers
-    })
+    }
+    return render(request, 'modoboa_amavis/viewheader.html', context)
 
 
 def check_mail_id(request, mail_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 modoboa>=1.7.0
 chardet
+html2text


### PR DESCRIPTION
If there's no plain text version available attempt to make one by sanitising the html version. The output isn't always pretty but it is readable, better than a blank screen and helps the user decide if the message is spam or ham.

This change adds a new dependency on [html2text](https://github.com/Alir3z4/html2text)