### PR TITLE
fix utf8 fields that contain escaped characters

### DIFF
--- a/modoboa_amavis/lib.py
+++ b/modoboa_amavis/lib.py
@@ -396,3 +396,15 @@ def setup_manual_learning_for_mbox(mbox):
                 create_user_and_use_policy(alias, policy)
             result = True
     return result
+
+
+def double_decode_utf8(s):
+    """Fix utf-8 strings that contain utf-8 escaped characters
+
+    Didn't even know the raw_unicode_escape encoding existed :)
+    https://docs.python.org/2/library/codecs.html?highlight=raw_unicode_escape#python-specific-encodings
+    https://docs.python.org/3/library/codecs.html?highlight=raw_unicode_escape#python-specific-encodings
+    """
+    assert isinstance(s, six.text_type), \
+        ("s should be of type %s" % type(six.text_type))
+    return s.encode("raw_unicode_escape").decode("utf-8")

--- a/modoboa_amavis/sql_connector.py
+++ b/modoboa_amavis/sql_connector.py
@@ -13,6 +13,7 @@ from django.utils.encoding import smart_bytes
 from modoboa.admin.models import Domain
 from modoboa.lib.db_utils import db_type
 
+from .lib import double_decode_utf8
 from .models import Quarantine, Msgrcpt, Maddr
 
 
@@ -163,9 +164,9 @@ class SQLconnector(object):
             if qm["rs"] == 'D':
                 continue
             m = {
-                "from": qm["mail__from_addr"],
+                "from": double_decode_utf8(qm["mail__from_addr"]),
                 "to": smart_bytes(qm["rid__email"]),
-                "subject": qm["mail__subject"],
+                "subject": double_decode_utf8(qm["mail__subject"]),
                 "mailid": smart_bytes(qm["mail__mail_id"]),
                 "date": datetime.datetime.fromtimestamp(qm["mail__time_num"]),
                 "type": qm["content"],


### PR DESCRIPTION
This only affects the amavis database I think django is being a little too smart converting utf-8 strings when they are loaded from the database and messes up with anything past \u0000FF.

I've mainly noticed this with messages that contain unicode emoji in the subject or cyrillic characters in from name/addresses.

No tests yet, I'm still working on a SQL dump of a real world amavis database for use in the tests.