### PR TITLE
Modoboa does not support the use of amavis $sql_partition_tag setting

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,13 @@ This plugin provides a simple management frontend for `amavisd-new
    you're planning to use the :ref:`selfservice`, you'll need version
    **2.8.0**.
 
+.. note::
+
+   ``$sql_partition_tag`` should remain undefined in ``amavisd.conf``. Modoboa
+   does not support the use of ``sql_partition_tag``, setting this value can
+   result in quarantined messages not showing or the wrong messages being
+   released or learnt as ham/spam.
+
 Contents:
 
 .. toctree::

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -45,6 +45,13 @@ amavis to allow quarantined messages release, read this :ref:`section
    Amavis configuration allows for separate lookup and storage
    databases but Modoboa doesn't support it yet.
 
+.. note::
+
+   ``$sql_partition_tag`` should remain undefined in ``amavisd.conf``. Modoboa
+   does not support the use of ``sql_partition_tag``, setting this value can
+   result in quarantined messages not showing or the wrong messages being
+   released or learnt as ham/spam.
+
 Connect Modoboa and Amavis
 ==========================
 

--- a/modoboa_amavis/factories.py
+++ b/modoboa_amavis/factories.py
@@ -100,7 +100,6 @@ class MsgsFactory(factory.DjangoModelFactory):
         model = models.Msgs
 
     mail_id = factory.Sequence(lambda n: smart_bytes("mailid{}".format(n)))
-    partition_tag = 0
     secret_id = factory.Sequence(lambda n: smart_bytes("id{}".format(n)))
     sid = factory.SubFactory(MaddrFactory)
     client_addr = "127.0.0.1"
@@ -119,7 +118,6 @@ class MsgrcptFactory(factory.DjangoModelFactory):
     class Meta:
         model = models.Msgrcpt
 
-    partition_tag = 0
     rseqnum = 1
     is_local = "Y"
     bl = "N"
@@ -134,7 +132,6 @@ class QuarantineFactory(factory.DjangoModelFactory):
     class Meta:
         model = models.Quarantine
 
-    partition_tag = 0
     chunk_ind = 1
     mail = factory.SubFactory(MsgsFactory)
 

--- a/modoboa_amavis/migrations/0001_initial.py
+++ b/modoboa_amavis/migrations/0001_initial.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Maddr',
             fields=[
-                ('partition_tag', models.IntegerField(unique=True, null=True, blank=True)),
+                ('partition_tag', models.IntegerField(default=0)),
                 ('id', models.BigIntegerField(serialize=False, primary_key=True)),
                 ('email', models.CharField(unique=True, max_length=255)),
                 ('domain', models.CharField(max_length=765)),
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Msgs',
             fields=[
-                ('partition_tag', models.IntegerField(null=True, blank=True)),
+                ('partition_tag', models.IntegerField(default=0)),
                 ('mail_id', models.CharField(max_length=12, serialize=False, primary_key=True)),
                 ('secret_id', models.CharField(max_length=12, blank=True)),
                 ('am_id', models.CharField(max_length=60)),
@@ -69,7 +69,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Msgrcpt',
             fields=[
-                ('partition_tag', models.IntegerField(null=True, blank=True)),
+                ('partition_tag', models.IntegerField(default=0)),
                 ('mail', models.ForeignKey(primary_key=True, serialize=False, to='modoboa_amavis.Msgs', on_delete=models.CASCADE)),
                 ('rseqnum', models.IntegerField(default=0)),
                 ('is_local', models.CharField(max_length=3)),
@@ -145,7 +145,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Quarantine',
             fields=[
-                ('partition_tag', models.IntegerField(null=True, blank=True)),
+                ('partition_tag', models.IntegerField(default=0)),
                 ('mail', models.ForeignKey(primary_key=True, serialize=False, to='modoboa_amavis.Msgs', on_delete=models.CASCADE)),
                 ('chunk_ind', models.IntegerField()),
                 ('mail_text', models.TextField()),

--- a/modoboa_amavis/models.py
+++ b/modoboa_amavis/models.py
@@ -39,7 +39,7 @@ class Mailaddr(models.Model):
 
 
 class Msgs(models.Model):
-    partition_tag = models.IntegerField(null=True, blank=True)
+    partition_tag = models.IntegerField(default=0)
     mail_id = models.CharField(max_length=12, primary_key=True)
     secret_id = models.BinaryField()
     am_id = models.CharField(max_length=60)
@@ -67,7 +67,7 @@ class Msgs(models.Model):
 
 
 class Msgrcpt(models.Model):
-    partition_tag = models.IntegerField(null=True, blank=True)
+    partition_tag = models.IntegerField(default=0)
     mail = models.ForeignKey(Msgs, primary_key=True, on_delete=models.CASCADE)
     rid = models.ForeignKey(Maddr, db_column='rid', on_delete=models.CASCADE)
     rseqnum = models.IntegerField(default=0)
@@ -208,7 +208,7 @@ class Policy(models.Model):
 
 
 class Quarantine(models.Model):
-    partition_tag = models.IntegerField(null=True, blank=True)
+    partition_tag = models.IntegerField(default=0)
     mail = models.ForeignKey(Msgs, primary_key=True, on_delete=models.CASCADE)
     chunk_ind = models.IntegerField()
     mail_text = models.BinaryField()


### PR DESCRIPTION
I was curious what the `partition_tag` field did in the `maddr`, `msgs`, `msgrcpt` and `quarantine` tables, it allows the tables to be partitioned up to make it easier to bulk delete old records. Records across these tables are only unique if `mail_id` **and** `partition_tag` are equal. There is no way to implement this feature in Django without using a lot of custom SQL and custom Models/Fields. Django only allows the use of one field in a foreign key relation, to implement this the relation between tables needs to use both mail_id and partition_tag:
```sql
SELECT *
FROM "msgrcpt"
    INNER JOIN "msgs" ON (
        "msgrcpt"."mail_id" = "msgs"."mail_id"
         AND
        "msgrcpt"."partition_tag" = "msgs"."partition_tag"
    )
```
---
If `$sql_partition_tag` is set to it's default (undefined) in `amavisd.conf`, `partition_tag` is always `0` and modoboa-amavis will work as expected. Setting this value can result in quarantined messages not showing or the wrong messages being released or learnt as ham/spam.

I've updated the documentation with an appropriate note and the models have been updated to set `partition_tag = 0` by default, this was already done in the factories but it should have been done in the model.
