### PR TITLE
refactor sql_connector.py and some code cleanup

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  ignore:
+  - **/migrations/*
+  - **/tests/*
+  - **/tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,30 +16,18 @@ sudo: false
 
 cache: pip
 
-services:
-  - postgres
-  - mysql
+addons:
+  postgresql: "9.3"
+  mysql: "5.5"
 
 before_install:
   - pip install codecov
-  - if [[ $DB = "POSTGRESQL" ]]; then pip install -q psycopg2; fi
-  - if [[ $DB = "MYSQL" ]]; then pip install -q mysqlclient; fi
-  - pip install -e git+https://github.com/tonioo/modoboa.git#egg=modoboa
+  - pip install -e git+https://github.com/modoboa/modoboa.git#egg=modoboa
 
 install:
   - pip install -q -r requirements.txt
   - pip install -q -r test-requirements.txt
   - python setup.py -q develop
-
-before_script:
-  - if [[ $DB = "POSTGRESQL" ]]; then psql -c "CREATE DATABASE modoboa_test;" -U postgres; fi
-  - if [[ $DB = "POSTGRESQL" ]]; then psql -c "CREATE DATABASE amavis_test;" -U postgres; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "CREATE DATABASE IF NOT EXISTS modoboa_test;" -uroot; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "CREATE USER 'modoboa'@'localhost' IDENTIFIED BY 'modoboa'" -uroot; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'modoboa'@'localhost';" -uroot; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "CREATE DATABASE IF NOT EXISTS amavis_test;" -uroot; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "CREATE USER 'amavis'@'localhost' IDENTIFIED BY 'amavis'" -uroot; fi
-  - if [[ $DB = "MYSQL" ]]; then mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'amavis'@'localhost';" -uroot; fi
 
 script:
   - cd test_project

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -33,6 +33,6 @@ Run the following commands to setup the database tables::
   $ python manage.py migrate
   $ python manage.py collectstatic
   $ python manage.py load_initial_data
-    
+  $ python manage.py check --deploy
 Finally, restart the python process running modoboa (uwsgi, gunicorn,
 apache, whatever).

--- a/modoboa_amavis/__init__.py
+++ b/modoboa_amavis/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 __version__ = "1.1.3"

--- a/modoboa_amavis/apps.py
+++ b/modoboa_amavis/apps.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """AppConfig for amavis."""
 
 from __future__ import unicode_literals

--- a/modoboa_amavis/apps.py
+++ b/modoboa_amavis/apps.py
@@ -14,4 +14,6 @@ class AmavisConfig(AppConfig):
     verbose_name = "Modoboa amavis frontend"
 
     def ready(self):
-        from . import handlers
+        # Import these to force registration of checks and signals
+        from . import checks  # noqa:F401
+        from . import handlers  # noqa:F401

--- a/modoboa_amavis/checks/__init__.py
+++ b/modoboa_amavis/checks/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+# Import these to force registration of checks
+from . import settings_checks  # noqa:F401

--- a/modoboa_amavis/checks/settings_checks.py
+++ b/modoboa_amavis/checks/settings_checks.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.core.checks import Warning, register
+from django.db import connections
+from django.utils.translation import ugettext as _
+
+
+W001 = Warning(
+    _("AMAVIS_DEFAULT_DATABASE_ENCODING does not match the character "
+      "encoding used by the Amavis database."),
+    hint=_("Check your database character encoding and set/update "
+           "AMAVIS_DEFAULT_DATABASE_ENCODING."),
+    id="modoboa-amavis.W001",
+)
+
+W002 = Warning(
+    _("Modoboa Amavis has not been tested using the selected database engine."),
+    hint=_("Try using PostgreSQL, MySQL or MariaDB."),
+    id="modoboa-amavis.W002",
+)
+
+
+@register(deploy=True)
+def check_amavis_database_encoding(app_configs, **kwargs):
+    """Ensure AMAVIS_DEFAULT_DATABASE_ENCODING is set to the correct value."""
+    errors = []
+    db_engine = settings.DATABASES["amavis"]["ENGINE"]
+    sql_query = None
+    if "postgresql" in db_engine:
+        sql_query = "SELECT pg_encoding_to_char(encoding) "\
+            "FROM pg_database "\
+            "WHERE datname = %s;"
+    elif "mysql" in db_engine:
+        sql_query = "SELECT DEFAULT_CHARACTER_SET_NAME "\
+            "FROM INFORMATION_SCHEMA.SCHEMATA "\
+            "WHERE SCHEMA_NAME = %s;"
+    elif "sqlite" in db_engine:
+        sql_query = "PRAGMA encoding;"
+    else:
+        errors.append(W002)
+        return errors
+
+    with connections["amavis"].cursor() as cursor:
+        if "sqlite" in db_engine:
+            cursor.execute(sql_query)
+        else:
+            cursor.execute(sql_query, [settings.DATABASES["amavis"]["NAME"]])
+        encoding = cursor.fetchone()[0]
+
+    if encoding.lower() != settings.AMAVIS_DEFAULT_DATABASE_ENCODING.lower():
+        errors.append(W001)
+
+    return errors

--- a/modoboa_amavis/constants.py
+++ b/modoboa_amavis/constants.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Modoboa amavis constants."""
 
 from __future__ import unicode_literals

--- a/modoboa_amavis/dbrouter.py
+++ b/modoboa_amavis/dbrouter.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 
@@ -8,20 +10,20 @@ class AmavisRouter(object):
 
     def db_for_read(self, model, **hints):
         """Point all operations on amavis models to 'amavis'."""
-        if model._meta.app_label == 'modoboa_amavis':
-            return 'amavis'
+        if model._meta.app_label == "modoboa_amavis":
+            return "amavis"
         return None
 
     def db_for_write(self, model, **hints):
         """Point all operations on amavis models to 'amavis'."""
-        if model._meta.app_label == 'modoboa_amavis':
-            return 'amavis'
+        if model._meta.app_label == "modoboa_amavis":
+            return "amavis"
         return None
 
     def allow_relation(self, obj1, obj2, **hints):
         """Allow any relation if a model in amavis is involved."""
-        if obj1._meta.app_label == 'modoboa_amavis' \
-           or obj2._meta.app_label == 'modoboa_amavis':
+        if obj1._meta.app_label == "modoboa_amavis" \
+           or obj2._meta.app_label == "modoboa_amavis":
             return True
         return None
 

--- a/modoboa_amavis/dbrouter.py
+++ b/modoboa_amavis/dbrouter.py
@@ -30,6 +30,10 @@ class AmavisRouter(object):
         Make sure the auth app only appears in the 'amavis'
         database.
         """
-        if db == "amavis":
-            return app_label == "modoboa_amavis"
+        if app_label == "modoboa_amavis":
+            # modoboa_amavis migrations should be created in the amavis database.
+            return (db == "amavis")
+        elif db == "amavis":
+            # Don't create non modoboa_amavis migrations in the amavis database.
+            return False
         return None

--- a/modoboa_amavis/factories.py
+++ b/modoboa_amavis/factories.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 """Amavis factories."""
 
 from __future__ import unicode_literals
@@ -88,7 +89,7 @@ class MaddrFactory(factory.DjangoModelFactory):
         model = models.Maddr
         django_get_or_create = ("email", )
 
-    id = factory.Sequence(lambda n: n)
+    id = factory.Sequence(lambda n: n)  # noqa:A003
     email = factory.Sequence(lambda n: "user_{}@domain.test".format(n))
     domain = "test.domain"
 
@@ -156,7 +157,7 @@ def create_quarantined_msg(rcpt, sender, rs, body, **kwargs):
 def create_spam(rcpt, sender="spam@evil.corp", rs=" "):
     """Create a spam."""
     body = SPAM_BODY.format(rcpt=rcpt, sender=sender)
-    body += 'fóó bár'
+    body += "fóó bár"
     return create_quarantined_msg(
         rcpt, sender, rs, body, bspam_level=999.0, content="S")
 

--- a/modoboa_amavis/factories.py
+++ b/modoboa_amavis/factories.py
@@ -6,11 +6,11 @@ from __future__ import unicode_literals
 import datetime
 import time
 
-from django.utils.encoding import smart_bytes
-
 import factory
 
 from . import models
+from .utils import smart_bytes
+
 
 SPAM_BODY = """X-Envelope-To: <{rcpt}>
 X-Envelope-To-Blocked: <{rcpt}>

--- a/modoboa_amavis/forms.py
+++ b/modoboa_amavis/forms.py
@@ -1,4 +1,5 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
+
 """
 Amavis forms.
 """
@@ -21,19 +22,19 @@ class DomainPolicyForm(forms.ModelForm):
 
     class Meta:
         model = Policy
-        fields = ('bypass_virus_checks', 'bypass_spam_checks',
-                  'spam_tag2_level', 'spam_subject_tag2',
-                  'spam_kill_level', 'bypass_banned_checks')
+        fields = ("bypass_virus_checks", "bypass_spam_checks",
+                  "spam_tag2_level", "spam_subject_tag2",
+                  "spam_kill_level", "bypass_banned_checks")
         widgets = {
-            'bypass_virus_checks': form_utils.HorizontalRadioSelect(),
-            'bypass_spam_checks': form_utils.HorizontalRadioSelect(),
-            'spam_tag2_level': forms.TextInput(
-                attrs={'class': 'form-control'}),
-            'spam_kill_level': forms.TextInput(
-                attrs={'class': 'form-control'}),
-            'spam_subject_tag2': forms.TextInput(
-                attrs={'class': 'form-control'}),
-            'bypass_banned_checks': form_utils.HorizontalRadioSelect(),
+            "bypass_virus_checks": form_utils.HorizontalRadioSelect(),
+            "bypass_spam_checks": form_utils.HorizontalRadioSelect(),
+            "spam_tag2_level": forms.TextInput(
+                attrs={"class": "form-control"}),
+            "spam_kill_level": forms.TextInput(
+                attrs={"class": "form-control"}),
+            "spam_subject_tag2": forms.TextInput(
+                attrs={"class": "form-control"}),
+            "bypass_banned_checks": form_utils.HorizontalRadioSelect(),
         }
 
     def __init__(self, *args, **kwargs):
@@ -51,12 +52,12 @@ class DomainPolicyForm(forms.ModelForm):
 
     def save(self, user, commit=True, **kwargs):
         policy = super(DomainPolicyForm, self).save(commit=False)
-        for field in ['bypass_spam_checks', 'bypass_virus_checks',
-                      'bypass_banned_checks']:
-            if getattr(policy, field) == '':
+        for field in ["bypass_spam_checks", "bypass_virus_checks",
+                      "bypass_banned_checks"]:
+            if getattr(policy, field) == "":
                 setattr(policy, field, None)
 
-        if self.cleaned_data['spam_subject_tag2_act']:
+        if self.cleaned_data["spam_subject_tag2_act"]:
             policy.spam_subject_tag2 = None
 
         if commit:

--- a/modoboa_amavis/handlers.py
+++ b/modoboa_amavis/handlers.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Amavis handlers."""
 
 from __future__ import unicode_literals
@@ -30,7 +32,7 @@ def menu(sender, location, user, **kwargs):
         return [
             {"name": "quarantine",
              "label": _("Quarantine"),
-             "url": reverse('modoboa_amavis:index')}
+             "url": reverse("modoboa_amavis:index")}
         ]
     return []
 

--- a/modoboa_amavis/handlers.py
+++ b/modoboa_amavis/handlers.py
@@ -19,7 +19,7 @@ from .lib import (
     create_user_and_use_policy, delete_user
 )
 from .models import Policy, Users
-from .sql_connector import get_connector
+from .sql_connector import SQLconnector
 from . import forms
 
 
@@ -163,7 +163,7 @@ def check_for_pending_requests(sender, include_all, **kwargs):
     if condition:
         return []
 
-    nbrequests = get_connector(user=request.user).get_pending_requests()
+    nbrequests = SQLconnector(user=request.user).get_pending_requests()
     if not nbrequests:
         return [{"id": "nbrequests", "counter": 0}] if include_all \
             else []

--- a/modoboa_amavis/lib.py
+++ b/modoboa_amavis/lib.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
 
@@ -9,10 +9,9 @@ import socket
 import string
 import struct
 
-import six
-
 from django.conf import settings
 from django.urls import reverse
+from django.utils import six
 from django.utils.translation import ugettext as _
 
 from django.contrib.auth.views import redirect_to_login
@@ -233,13 +232,13 @@ class QuarantineNavigationParameters(NavigationParameters):
     """
     def __init__(self, request):
         super(QuarantineNavigationParameters, self).__init__(
-            request, 'quarantine_navparams'
+            request, "quarantine_navparams"
         )
         self.parameters += [
-            ('pattern', '', False),
-            ('criteria', 'from_addr', False),
-            ('msgtype', None, False),
-            ('viewrequests', None, False)
+            ("pattern", "", False),
+            ("criteria", "from_addr", False),
+            ("msgtype", None, False),
+            ("viewrequests", None, False)
         ]
 
     def _store_page(self):

--- a/modoboa_amavis/lib.py
+++ b/modoboa_amavis/lib.py
@@ -13,7 +13,6 @@ import six
 
 from django.conf import settings
 from django.urls import reverse
-from django.utils.encoding import smart_bytes, smart_text
 from django.utils.translation import ugettext as _
 
 from django.contrib.auth.views import redirect_to_login
@@ -26,6 +25,7 @@ from modoboa.lib.web_utils import NavigationParameters
 from modoboa.parameters import tools as param_tools
 
 from .models import Users, Policy
+from .utils import smart_bytes, smart_text
 
 
 def selfservice(ssfunc=None):
@@ -208,7 +208,7 @@ class SpamassassinClient(object):
             cmd, pinput=smart_bytes(msg), **self._learn_cmd_kwargs)
         if code in self._expected_exit_codes:
             return True
-        self.error = output
+        self.error = smart_text(output)
         return False
 
     def learn_spam(self, rcpt, msg):

--- a/modoboa_amavis/management/commands/amnotify.py
+++ b/modoboa_amavis/management/commands/amnotify.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 
 from __future__ import print_function, unicode_literals
 
@@ -20,7 +20,7 @@ from ...sql_connector import SQLconnector
 
 
 class Command(BaseCommand):
-    help = 'Amavis notification tool'
+    help = "Amavis notification tool"  # noqa:A003
 
     sender = None
     baseurl = None
@@ -88,7 +88,7 @@ class Command(BaseCommand):
                 messages.append(self._build_message(rcpt, total, reqs))
 
         # Then super administators.
-        reqs = Msgrcpt.objects.filter(rs='p')
+        reqs = Msgrcpt.objects.filter(rs="p")
         total = reqs.count()
         if total:
             reqs = reqs.all()[:10]

--- a/modoboa_amavis/management/commands/amnotify.py
+++ b/modoboa_amavis/management/commands/amnotify.py
@@ -16,7 +16,7 @@ from modoboa.parameters import tools as param_tools
 
 from ...models import Msgrcpt
 from ...modo_extension import Amavis
-from ...sql_connector import get_connector
+from ...sql_connector import SQLconnector
 
 
 class Command(BaseCommand):
@@ -79,7 +79,7 @@ class Command(BaseCommand):
             if not hasattr(da, "mailbox"):
                 continue
             rcpt = da.mailbox.full_address
-            reqs = get_connector().get_domains_pending_requests(
+            reqs = SQLconnector().get_domains_pending_requests(
                 Domain.objects.get_for_admin(da).values_list("name", flat=True)
             )
             total = reqs.count()

--- a/modoboa_amavis/management/commands/qcleanup.py
+++ b/modoboa_amavis/management/commands/qcleanup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# coding: utf-8
+# -*- coding: utf-8 -*-
 
 from __future__ import print_function, unicode_literals
 
@@ -16,7 +16,7 @@ from ...modo_extension import Amavis
 
 class Command(BaseCommand):
     args = ""
-    help = "Amavis quarantine cleanup"
+    help = "Amavis quarantine cleanup"  # noqa:A003
 
     def add_arguments(self, parser):
         """Add extra arguments to command line."""

--- a/modoboa_amavis/migrations/0001_initial.py
+++ b/modoboa_amavis/migrations/0001_initial.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from __future__ import unicode_literals
 
 from django.db import models, migrations

--- a/modoboa_amavis/models.py
+++ b/modoboa_amavis/models.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # This is an auto-generated Django model module.
 # You'll have to do the following manually to clean this up:
 #     * Rearrange models' order
@@ -18,7 +20,7 @@ from django.utils.translation import ugettext_lazy
 
 class Maddr(models.Model):
     partition_tag = models.IntegerField(default=0)
-    id = models.BigIntegerField(primary_key=True)
+    id = models.BigIntegerField(primary_key=True)  # noqa:A003
     email = models.CharField(max_length=255)
     domain = models.CharField(max_length=255)
 
@@ -29,7 +31,7 @@ class Maddr(models.Model):
 
 
 class Mailaddr(models.Model):
-    id = models.IntegerField(primary_key=True)
+    id = models.IntegerField(primary_key=True)  # noqa:A003
     priority = models.IntegerField()
     email = models.CharField(unique=True, max_length=255)
 
@@ -221,7 +223,7 @@ class Quarantine(models.Model):
 
 
 class Users(models.Model):
-    id = models.AutoField(primary_key=True)
+    id = models.AutoField(primary_key=True)  # noqa:A003
     priority = models.IntegerField()
     policy = models.ForeignKey(Policy, on_delete=models.CASCADE)
     email = models.CharField(unique=True, max_length=255)

--- a/modoboa_amavis/modo_extension.py
+++ b/modoboa_amavis/modo_extension.py
@@ -1,4 +1,5 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
+
 """
 Amavis management frontend.
 

--- a/modoboa_amavis/settings.py
+++ b/modoboa_amavis/settings.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Amavis frontend default settings."""
 
 from __future__ import unicode_literals

--- a/modoboa_amavis/sql_connector.py
+++ b/modoboa_amavis/sql_connector.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """SQL connector module."""
 
 from __future__ import unicode_literals
@@ -61,7 +63,7 @@ class SQLconnector(object):
         from django.db import connections, transaction
 
         with transaction.atomic():
-            cursor = connections['amavis'].cursor()
+            cursor = connections["amavis"].cursor()
             cursor.execute(query, args)
 
     def _apply_msgrcpt_simpleuser_filter(self, flt):
@@ -76,7 +78,7 @@ class SQLconnector(object):
 
     def _apply_msgrcpt_filters(self, flt):
         """Apply filters based on user's role."""
-        if self.user.role == 'SimpleUsers':
+        if self.user.role == "SimpleUsers":
             flt = self._apply_msgrcpt_simpleuser_filter(flt)
         elif not self.user.is_superuser:
             doms = Domain.objects.get_for_admin(
@@ -90,13 +92,13 @@ class SQLconnector(object):
         Filters: rs, rid, content
         """
         flt = (
-            Q(rs__in=[' ', 'V', 'R', 'p', 'S', 'H'])
-            if self.navparams.get('viewrequests', '0') != '1' else Q(rs='p')
+            Q(rs__in=[" ", "V", "R", "p", "S", "H"])
+            if self.navparams.get("viewrequests", "0") != "1" else Q(rs="p")
         )
         flt = self._apply_msgrcpt_filters(flt)
         pattern = self.navparams.get("pattern", "")
         if pattern:
-            criteria = self.navparams.get('criteria')
+            criteria = self.navparams.get("criteria")
             if criteria == "both":
                 criteria = "from_addr,subject,to"
             search_flt = None
@@ -116,7 +118,7 @@ class SQLconnector(object):
                 )
             if search_flt:
                 flt &= search_flt
-        msgtype = self.navparams.get('msgtype', None)
+        msgtype = self.navparams.get("msgtype", None)
         if msgtype is not None:
             flt &= Q(content=msgtype)
 
@@ -159,7 +161,7 @@ class SQLconnector(object):
         """Fetch a range of messages from the internal cache."""
         emails = []
         for qm in self.messages[start - 1:stop]:
-            if qm["rs"] == 'D':
+            if qm["rs"] == "D":
                 continue
             m = {
                 "from": fix_utf8_encoding(qm["mail__from_addr"]),
@@ -171,9 +173,9 @@ class SQLconnector(object):
                 "score": qm["bspam_level"],
                 "status": qm["rs"]
             }
-            if qm["rs"] in ['', ' ']:
+            if qm["rs"] in ["", " "]:
                 m["class"] = "unseen"
-            elif qm["rs"] == 'p':
+            elif qm["rs"] == "p":
                 m["class"] = "pending"
             emails.append(m)
         return emails
@@ -206,11 +208,11 @@ class SQLconnector(object):
     def get_domains_pending_requests(self, domains):
         """Retrieve pending release requests for a list of domains."""
         return Msgrcpt.objects.filter(
-            rs='p', rid__domain__in=reverse_domain_names(domains))
+            rs="p", rid__domain__in=reverse_domain_names(domains))
 
     def get_pending_requests(self):
         """Return the number of requests currently pending."""
-        rq = Q(rs='p')
+        rq = Q(rs="p")
         if not self.user.is_superuser:
             doms = Domain.objects.get_for_admin(self.user)
             if not doms.exists():

--- a/modoboa_amavis/sql_connector.py
+++ b/modoboa_amavis/sql_connector.py
@@ -8,12 +8,12 @@ import chardet
 
 from django.conf import settings
 from django.db.models import Q
-from django.utils.encoding import smart_bytes
 
 from modoboa.admin.models import Domain
 from modoboa.lib.db_utils import db_type
 
 from .models import Quarantine, Msgrcpt, Maddr
+from .utils import fix_utf8_encoding, smart_bytes
 
 
 def reverse_domain_names(domains):
@@ -163,9 +163,9 @@ class SQLconnector(object):
             if qm["rs"] == 'D':
                 continue
             m = {
-                "from": qm["mail__from_addr"],
+                "from": fix_utf8_encoding(qm["mail__from_addr"]),
                 "to": smart_bytes(qm["rid__email"]),
-                "subject": qm["mail__subject"],
+                "subject": fix_utf8_encoding(qm["mail__subject"]),
                 "mailid": smart_bytes(qm["mail__mail_id"]),
                 "date": datetime.datetime.fromtimestamp(qm["mail__time_num"]),
                 "type": qm["content"],

--- a/modoboa_amavis/sql_email.py
+++ b/modoboa_amavis/sql_email.py
@@ -7,13 +7,13 @@ An email representation based on a database record.
 from __future__ import unicode_literals
 
 from django.template.loader import render_to_string
-from django.utils.encoding import smart_text
 
 from html2text import HTML2Text
 
 from modoboa.lib.email_utils import Email
 
 from .sql_connector import get_connector
+from .utils import smart_text
 
 
 class SQLemail(Email):

--- a/modoboa_amavis/sql_email.py
+++ b/modoboa_amavis/sql_email.py
@@ -27,8 +27,8 @@ class SQLemail(Email):
 
         qreason = self.msg["X-Amavis-Alert"]
         if qreason:
-            if ',' in qreason:
-                self.qtype, qreason = qreason.split(',', 1)
+            if "," in qreason:
+                self.qtype, qreason = qreason.split(",", 1)
             elif qreason.startswith("BAD HEADER SECTION "):
                 # Workaround for amavis <= 2.8.0 :p
                 self.qtype = "BAD HEADER SECTION"

--- a/modoboa_amavis/sql_email.py
+++ b/modoboa_amavis/sql_email.py
@@ -12,7 +12,7 @@ from html2text import HTML2Text
 
 from modoboa.lib.email_utils import Email
 
-from .sql_connector import get_connector
+from .sql_connector import SQLconnector
 from .utils import smart_text
 
 
@@ -38,7 +38,7 @@ class SQLemail(Email):
             self.qreason = qreason
 
     def _fetch_message(self):
-        return get_connector().get_mail_content(self.mailid)
+        return SQLconnector().get_mail_content(self.mailid)
 
     @property
     def body(self):

--- a/modoboa_amavis/templatetags/amavis_tags.py
+++ b/modoboa_amavis/templatetags/amavis_tags.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Amavis frontend template tags.
 """
@@ -29,19 +31,19 @@ def viewm_menu(user, mail_id, rcpt):
          "img": "fa fa-check",
          "class": "btn-success",
          "url": (
-             reverse('modoboa_amavis:mail_release', args=[mail_id]) +
+             reverse("modoboa_amavis:mail_release", args=[mail_id]) +
              ("?rcpt=%s" % rcpt if rcpt else "")),
          "label": _("Release")},
         {"name": "delete",
          "class": "btn-danger",
          "img": "fa fa-trash",
          "url": (
-             reverse('modoboa_amavis:mail_delete', args=[mail_id]) +
+             reverse("modoboa_amavis:mail_delete", args=[mail_id]) +
              ("?rcpt=%s" % rcpt if rcpt else "")),
          "label": _("Delete")},
         {"name": "headers",
          "class": "btn-default",
-         "url": reverse('modoboa_amavis:headers_detail', args=[mail_id]),
+         "url": reverse("modoboa_amavis:headers_detail", args=[mail_id]),
          "label": _("View full headers")},
     ]
 
@@ -69,14 +71,14 @@ def viewm_menu(user, mail_id, rcpt):
             ]
         })
 
-    menu = render_to_string('common/buttons_list.html',
+    menu = render_to_string("common/buttons_list.html",
                             {"entries": entries, "extraclasses": "pull-left"})
 
     entries = [{"name": "close",
                 "url": "javascript:history.go(-1);",
                 "img": "icon-remove"}]
     menu += render_to_string(
-        'common/buttons_list.html',
+        "common/buttons_list.html",
         {"entries": entries, "extraclasses": "pull-right"}
     )
 
@@ -105,7 +107,7 @@ def viewm_menu_simple(user, mail_id, rcpt, secret_id=""):
          "label": _("Delete")},
     ]
 
-    return render_to_string('common/buttons_list.html',
+    return render_to_string("common/buttons_list.html",
                             {"entries": entries})
 
 
@@ -135,5 +137,5 @@ def msgtype_to_html(msgtype):
     """Transform a message type to a bootstrap label."""
     color = constants.MESSAGE_TYPE_COLORS.get(msgtype, "default")
     return mark_safe(
-        '<span class="label label-{}" title="{}">{}</span>'.format(
+        "<span class=\"label label-{}\" title=\"{}\">{}</span>".format(
             color, constants.MESSAGE_TYPES[msgtype], msgtype))

--- a/modoboa_amavis/test_runners.py
+++ b/modoboa_amavis/test_runners.py
@@ -1,18 +1,11 @@
+# -*- coding: utf-8 -*-
+
 """Custom test runner."""
 
 from __future__ import unicode_literals
 
 from django.apps import apps
 from django.test.runner import DiscoverRunner
-
-
-
-class DisableMigrations(object):
-    def __contains__(self, item):
-        return True
-
-    def __getitem__(self, item):
-        return "notmigrations"
 
 
 class UnManagedModelTestRunner(DiscoverRunner):
@@ -22,23 +15,21 @@ class UnManagedModelTestRunner(DiscoverRunner):
     Many thanks to the Caktus Group: http://bit.ly/1N8TcHW
     """
 
-    # ALLOWED_MODELS = ["maddr", "msgs", "policy", "users"]
+    unmanaged_models = []
 
     def setup_test_environment(self, *args, **kwargs):
-        self.unmanaged_models = []
+        """Mark modoboa_amavis models as managed during testing
+        During database setup migrations are only run for managed models"""
         for m in apps.get_models():
-            condition = (
-                m._meta.app_label == "modoboa_amavis")
-                # m._meta.model_name in self.ALLOWED_MODELS)
-            if condition:
+            if m._meta.app_label == "modoboa_amavis":
                 self.unmanaged_models.append(m)
                 m._meta.managed = True
         super(UnManagedModelTestRunner, self).setup_test_environment(
             *args, **kwargs)
 
     def teardown_test_environment(self, *args, **kwargs):
+        """Revert modoboa_amavis models to unmanaged"""
         super(UnManagedModelTestRunner, self).teardown_test_environment(
             *args, **kwargs)
-        # reset unmanaged models
         for m in self.unmanaged_models:
             m._meta.managed = False

--- a/modoboa_amavis/tests/test_checks.py
+++ b/modoboa_amavis/tests/test_checks.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from ..checks import settings_checks
+
+
+class CheckSessionCookieSecureTest(TestCase):
+    @override_settings(AMAVIS_DEFAULT_DATABASE_ENCODING="LATIN-1")
+    def test_amavis_database_encoding_incorrect(self):
+        """
+        If AMAVIS_DEFAULT_DATABASE_ENCODING is incorrect provide one warning.
+        """
+        self.assertEqual(
+            settings_checks.check_amavis_database_encoding(None),
+            [settings_checks.W001]
+        )
+
+    @override_settings(AMAVIS_DEFAULT_DATABASE_ENCODING="UTF-8")
+    def test_amavis_database_encoding_correct(self):
+        """
+        If AMAVIS_DEFAULT_DATABASE_ENCODING is correct, there's no warning about it.
+        """
+        self.assertEqual(
+            settings_checks.check_amavis_database_encoding(None),
+            []
+        )

--- a/modoboa_amavis/tests/test_handlers.py
+++ b/modoboa_amavis/tests/test_handlers.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Amavis tests."""
 
 from __future__ import unicode_literals
@@ -108,7 +110,7 @@ class ManualLearningTestCase(ModoTestCase):
     """Check manual learning mode."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa:N802
         """Create test data."""
         super(ManualLearningTestCase, cls).setUpTestData()
         admin_factories.populate_database()

--- a/modoboa_amavis/tests/test_management_commands.py
+++ b/modoboa_amavis/tests/test_management_commands.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Management commands tests."""
 
 from __future__ import unicode_literals

--- a/modoboa_amavis/tests/test_views.py
+++ b/modoboa_amavis/tests/test_views.py
@@ -10,13 +10,13 @@ from django.core import mail
 from django.core.management import call_command
 from django.urls import reverse
 from django.test import override_settings
-from django.utils.encoding import smart_text
 
 from modoboa.admin import factories as admin_factories
 from modoboa.core import models as core_models
 from modoboa.lib.tests import ModoTestCase
 
 from .. import factories
+from ..utils import smart_text
 
 
 class TestDataMixin(object):
@@ -70,7 +70,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
 
     def test_viewmail(self):
         """Test view_mail view."""
-        mail_id = self.msgrcpt.mail.mail_id
+        mail_id = smart_text(self.msgrcpt.mail.mail_id)
         url = reverse("modoboa_amavis:mail_detail", args=[mail_id])
         url = "{}?rcpt={}".format(url, smart_text(self.msgrcpt.rid.email))
         response = self.ajax_get(url)
@@ -91,7 +91,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
         """Test view_mail in self-service mode."""
         self.client.logout()
 
-        mail_id = self.msgrcpt.mail.mail_id
+        mail_id = smart_text(self.msgrcpt.mail.mail_id)
         url = reverse("modoboa_amavis:mail_detail", args=[mail_id])
         url = "{}?secret_id={}".format(
             url, smart_text(self.msgrcpt.mail.secret_id))
@@ -113,7 +113,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
 
     def test_viewheaders(self):
         """Test headers display."""
-        mail_id = self.msgrcpt.mail.mail_id
+        mail_id = smart_text(self.msgrcpt.mail.mail_id)
         url = reverse("modoboa_amavis:headers_detail", args=[mail_id])
         response = self.client.get(url)
         self.assertContains(response, b"X-Spam-Flag: YES")
@@ -125,7 +125,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
         url = reverse("modoboa_amavis:_mail_list")
         response = self.ajax_get(url)
 
-        mail_id = self.msgrcpt.mail.mail_id
+        mail_id = smart_text(self.msgrcpt.mail.mail_id)
         url = reverse("modoboa_amavis:mail_delete", args=[mail_id])
         data = {"rcpt": smart_text(self.msgrcpt.rid.email)}
         response = self.ajax_post(url, data)
@@ -137,7 +137,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
     def test_delete_selfservice(self):
         """Test delete view in self-service mode."""
         self.client.logout()
-        mail_id = self.msgrcpt.mail.mail_id
+        mail_id = smart_text(self.msgrcpt.mail.mail_id)
         url = reverse("modoboa_amavis:mail_delete", args=[mail_id])
         url = "{}?secret_id={}".format(
             url, smart_text(self.msgrcpt.mail.secret_id))
@@ -157,7 +157,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
         response = self.ajax_get(url)
 
         mock_socket.return_value.recv.return_value = b"250 1234 Ok\r\n"
-        mail_id = self.msgrcpt.mail.mail_id
+        mail_id = smart_text(self.msgrcpt.mail.mail_id)
         url = reverse("modoboa_amavis:mail_release", args=[mail_id])
         data = {"rcpt": smart_text(self.msgrcpt.rid.email)}
         response = self.ajax_post(url, data)
@@ -171,7 +171,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
         """Test release view."""
         mock_socket.return_value.recv.return_value = b"250 1234 Ok\r\n"
         self.client.logout()
-        mail_id = self.msgrcpt.mail.mail_id
+        mail_id = smart_text(self.msgrcpt.mail.mail_id)
         base_url = reverse("modoboa_amavis:mail_release", args=[mail_id])
         self.set_global_parameter("self_service", True)
         # Missing rcpt -> fails
@@ -207,7 +207,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
         url = reverse("modoboa_amavis:_mail_list")
         response = self.ajax_get(url)
 
-        mail_id = self.msgrcpt.mail.mail_id
+        mail_id = smart_text(self.msgrcpt.mail.mail_id)
         url = reverse("modoboa_amavis:mail_release", args=[mail_id])
         data = {"rcpt": smart_text(self.msgrcpt.rid.email)}
         response = self.ajax_post(url, data)
@@ -221,7 +221,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
 
     def _test_mark_message(self, action, status):
         """Mark message common code."""
-        mail_id = self.msgrcpt.mail.mail_id
+        mail_id = smart_text(self.msgrcpt.mail.mail_id)
         url = reverse("modoboa_amavis:mail_mark_as_" + action, args=[mail_id])
         data = {"rcpt": smart_text(self.msgrcpt.rid.email)}
         response = self.ajax_post(url, data)
@@ -280,7 +280,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
         """Test learning when connected as a simple user."""
         user = core_models.User.objects.get(username="user@test.com")
         self.client.force_login(user)
-        mail_id = self.msgrcpt.mail.mail_id
+        mail_id = smart_text(self.msgrcpt.mail.mail_id)
         url = reverse("modoboa_amavis:mail_mark_as_ham", args=[mail_id])
         data = {"rcpt": smart_text(self.msgrcpt.rid.email)}
         response = self.ajax_post(url, data)

--- a/modoboa_amavis/tests/test_views.py
+++ b/modoboa_amavis/tests/test_views.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Amavis tests."""
 
 from __future__ import unicode_literals
@@ -23,7 +25,7 @@ class TestDataMixin(object):
     """A mixin to provide test data."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa:N802
         """Create some content."""
         super(TestDataMixin, cls).setUpTestData()
         cls.msgrcpt = factories.create_spam("user@test.com")
@@ -34,7 +36,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
     """Test views."""
 
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(cls):  # noqa:N802
         """Create test data."""
         super(ViewsTestCase, cls).setUpTestData()
         admin_factories.populate_database()
@@ -62,10 +64,10 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
         msgrcpt = factories.create_virus("user@test.com")
         response = self.ajax_get("{}?msgtype=V".format(url))
         self.assertIn(
-            '<tr id="{}">'.format(smart_text(msgrcpt.mail.mail_id)),
+            "<tr id=\"{}\">".format(smart_text(msgrcpt.mail.mail_id)),
             response["listing"])
         self.assertNotIn(
-            '<tr id="{}">'.format(smart_text(self.msgrcpt.mail.mail_id)),
+            "<tr id=\"{}\">".format(smart_text(self.msgrcpt.mail.mail_id)),
             response["listing"])
 
     def test_viewmail(self):
@@ -251,9 +253,9 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
         url = reverse("modoboa_amavis:learning_recipient_set")
         url = "{}?type=ham&selection={}".format(url, selection)
         response = self.client.get(url)
-        self.assertContains(response, 'value="global"')
-        self.assertContains(response, 'value="domain"')
-        self.assertNotContains(response, 'value="user"')
+        self.assertContains(response, "value=\"global\"")
+        self.assertContains(response, "value=\"domain\"")
+        self.assertNotContains(response, "value=\"user\"")
         data = {
             "selection": selection,
             "ltype": "ham",
@@ -264,7 +266,7 @@ class ViewsTestCase(TestDataMixin, ModoTestCase):
         # Check user level learning
         self.set_global_parameter("user_level_learning", True)
         response = self.client.get(url)
-        self.assertContains(response, 'value="user"')
+        self.assertContains(response, "value=\"user\"")
         data = {
             "selection": selection,
             "ltype": "ham",

--- a/modoboa_amavis/urls.py
+++ b/modoboa_amavis/urls.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Amavis urls."""
 
 from __future__ import unicode_literals

--- a/modoboa_amavis/utils.py
+++ b/modoboa_amavis/utils.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+"""A collection of utility functions for working with the Amavis database."""
+
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db.models.expressions import Func
+from django.utils import six
+from django.utils.encoding import smart_bytes as django_smart_bytes
+from django.utils.encoding import smart_str as django_smart_str
+from django.utils.encoding import smart_text as django_smart_text
+
+
+"""
+Byte fields for text data are EVIL.
+
+MySQL uses `varbyte` fields which mysqlclient client maps to `str` (Py2) or
+`bytes` (Py3), Djangos smart_* functions work as expected.
+
+PostgreSQL uses `bytea` fields which psycopg2 maps to `memoryview`,
+Djangos smart_* functions don't work as expected, you must call `tobytes()` on
+the memoryview for them to work.
+
+For convenience use smart_bytes and smart_text from this file in modoboa_amavis
+to avoid any headaches.
+"""
+
+
+def smart_bytes(value, *args, **kwargs):
+    if isinstance(value, memoryview):
+        value = value.tobytes()
+    return django_smart_bytes(value, *args, **kwargs)
+
+
+def smart_str(value, *args, **kwargs):
+    if isinstance(value, memoryview):
+        value = value.tobytes()
+    return django_smart_str(value, *args, **kwargs)
+
+
+def smart_text(value, *args, **kwargs):
+    if isinstance(value, memoryview):
+        value = value.tobytes()
+    return django_smart_text(value, *args, **kwargs)
+
+
+def fix_utf8_encoding(value):
+    """Fix utf-8 strings that contain utf-8 escaped characters.
+
+    msgs.from_addr and msgs.subject potentialy contain badly escaped utf-8
+    characters, this utility function fixes that and should be used anytime
+    these fields are accesses.
+
+    Didn't even know the raw_unicode_escape encoding existed :)
+    https://docs.python.org/2/library/codecs.html?highlight=raw_unicode_escape#python-specific-encodings
+    https://docs.python.org/3/library/codecs.html?highlight=raw_unicode_escape#python-specific-encodings
+    """
+    assert isinstance(value, six.text_type), \
+        ("value should be of type %s" % six.text_type.__name__)
+    return value.encode("raw_unicode_escape").decode("utf-8")
+
+
+class ConvertFrom(Func):
+    """Convert a binary value to a string.
+    Calls the database specific function to convert a binary value to a string
+    using the encoding set in AMAVIS_DEFAULT_DATABASE_ENCODING.
+    """
+
+    """PostgreSQL implementation.
+    See https://www.postgresql.org/docs/9.3/static/functions-string.html#FUNCTIONS-STRING-OTHER"""
+    function = "convert_from"
+    arity = 1
+    template = "%(function)s(%(expressions)s, '{}')".format(
+        settings.AMAVIS_DEFAULT_DATABASE_ENCODING)
+
+    def as_mysql(self, compiler, connection):
+        """MySQL implementation.
+        See https://dev.mysql.com/doc/refman/5.5/en/cast-functions.html#function_convert"""
+        return super(ConvertFrom, self).as_sql(
+            compiler, connection,
+            function="CONVERT",
+            template="%(function)s(%(expressions)s USING {})".format(
+                settings.AMAVIS_DEFAULT_DATABASE_ENCODING),
+            arity=1,
+        )
+
+    def as_sqlite(self, compiler, connection):
+        """SQLite implementation.
+        SQLite has no equivilant function, just return the field."""
+        return super(ConvertFrom, self).as_sql(
+            compiler, connection,
+            template="%(expressions)s",
+            arity=1,
+        )

--- a/modoboa_amavis/views.py
+++ b/modoboa_amavis/views.py
@@ -10,7 +10,6 @@ from django.urls import reverse
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render
 from django.template import loader
-from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _, ungettext
 
 from django.contrib.auth.decorators import login_required
@@ -33,6 +32,7 @@ from .forms import LearningRecipientForm
 from .models import Msgrcpt
 from .sql_connector import get_connector
 from .sql_email import SQLemail
+from .utils import smart_text
 
 
 def empty_quarantine():

--- a/modoboa_amavis/views.py
+++ b/modoboa_amavis/views.py
@@ -1,7 +1,9 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
+
 """
 Amavis quarantine views.
 """
+
 from __future__ import unicode_literals
 
 import six
@@ -92,7 +94,7 @@ def _listing(request):
 
     Called the first time the listing page is displayed.
     """
-    if not request.user.is_superuser and request.user.role != 'SimpleUsers':
+    if not request.user.is_superuser and request.user.role != "SimpleUsers":
         if not Domain.objects.get_for_admin(request.user).count():
             return empty_quarantine()
 
@@ -110,7 +112,7 @@ def _listing(request):
         }, request
     )
     del context["rows"]
-    if request.session.get('location', 'listing') != 'listing':
+    if request.session.get("location", "listing") != "listing":
         context["menu"] = quar_menu(request.user)
     request.session["location"] = "listing"
     return render_to_json_response(context)
@@ -169,16 +171,16 @@ def viewmail(request, mail_id):
     if rcpt is None:
         raise BadRequest(_("Invalid request"))
     if request.user.email == rcpt:
-        SQLconnector().set_msgrcpt_status(rcpt, mail_id, 'V')
+        SQLconnector().set_msgrcpt_status(rcpt, mail_id, "V")
     elif hasattr(request.user, "mailbox"):
         mb = request.user.mailbox
         if rcpt == mb.full_address or rcpt in mb.alias_addresses:
-            SQLconnector().set_msgrcpt_status(rcpt, mail_id, 'V')
+            SQLconnector().set_msgrcpt_status(rcpt, mail_id, "V")
     content = loader.get_template("modoboa_amavis/_email_display.html").render(
         {"mail_id": mail_id})
     menu = viewm_menu(request.user, mail_id, rcpt)
     ctx = getctx("ok", menu=menu, listing=content)
-    request.session['location'] = 'viewmail'
+    request.session["location"] = "viewmail"
     return render_to_json_response(ctx)
 
 
@@ -207,7 +209,7 @@ def check_mail_id(request, mail_id):
 def get_user_valid_addresses(user):
     """Retrieve all valid addresses of a user."""
     valid_addresses = []
-    if user.role == 'SimpleUsers':
+    if user.role == "SimpleUsers":
         valid_addresses.append(user.email)
         try:
             mb = Mailbox.objects.get(user=user)
@@ -223,7 +225,7 @@ def delete_selfservice(request, mail_id):
     if rcpt is None:
         raise BadRequest(_("Invalid request"))
     try:
-        SQLconnector().set_msgrcpt_status(rcpt, mail_id, 'D')
+        SQLconnector().set_msgrcpt_status(rcpt, mail_id, "D")
     except Msgrcpt.DoesNotExist:
         raise BadRequest(_("Invalid request"))
     return render_to_json_response(_("Message deleted"))
@@ -242,7 +244,7 @@ def delete(request, mail_id):
         r, i = mid.split()
         if valid_addresses and r not in valid_addresses:
             continue
-        connector.set_msgrcpt_status(r, i, 'D')
+        connector.set_msgrcpt_status(r, i, "D")
     message = ungettext("%(count)d message deleted successfully",
                         "%(count)d messages deleted successfully",
                         len(mail_id)) % {"count": len(mail_id)}
@@ -298,7 +300,7 @@ def release(request, mail_id):
        not param_tools.get_global_parameter("user_can_release"):
         for msgrcpt in msgrcpts:
             connector.set_msgrcpt_status(
-                msgrcpt.rid.email, msgrcpt.mail.mail_id, 'p'
+                msgrcpt.rid.email, msgrcpt.mail.mail_id, "p"
             )
         message = ungettext("%(count)d request sent",
                             "%(count)d requests sent",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,4 @@
 factory-boy>=2.4
 testfixtures==4.7.0
+psycopg2>=2.5.4
+mysqlclient>=1.3.3

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Django settings for test_project project.
 

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -286,8 +286,10 @@ TEST_RUNNER = "modoboa_amavis.test_runners.UnManagedModelTestRunner"
 DATABASES.update({  # noqa
     'amavis': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'amavis_test.db',
+        'NAME': 'amavis.db',
         'PORT': '',
         'ATOMIC_REQUESTS': True,
     },
 })
+# sqlite defaults to UTF-8
+AMAVIS_DEFAULT_DATABASE_ENCODING = 'UTF-8'


### PR DESCRIPTION
This PR grew a bit it to include some small random code cleanups as well.

- ac91819, be0b5b3 carry on from modoboa/modoboa#1340

- 6f824b6 only apply amavis migrations to the amavis database, this only applies during testing as migrations aren't used in a production setup for the amavis database

- 1cba316 and 5930953 code cleanups

- c9ef561 utility functions to make it easier to work with the amavis database

- b81e109 refactor sql_connector.py 
QuerySet.extra() should be used as a last resort, it is no longer maintained and the Django maintainers intend on removing it in the future.
https://docs.djangoproject.com/en/1.11/ref/models/querysets/#extra
The custom SQL has been replaced with ConvertFrom() and annotations. This also removes the requirement for a database Specific SQLconnector() as the database specific code is handled in the ConvertFrom() function class.
