### PR TITLE
identify mail_id as a 16 character binary field

### DIFF
--- a/modoboa_amavis/models.py
+++ b/modoboa_amavis/models.py
@@ -40,7 +40,7 @@ class Mailaddr(models.Model):
 
 class Msgs(models.Model):
     partition_tag = models.IntegerField(default=0)
-    mail_id = models.CharField(max_length=12, primary_key=True)
+    mail_id = models.BinaryField(max_length=16, primary_key=True)
     secret_id = models.BinaryField()
     am_id = models.CharField(max_length=60)
     time_num = models.IntegerField()

--- a/modoboa_amavis/sql_connector.py
+++ b/modoboa_amavis/sql_connector.py
@@ -196,7 +196,7 @@ class SQLconnector:
 
         return Msgrcpt.objects\
             .annotate(str_email=ConvertFrom("rid__email"))\
-            .get(mail=mailid, str_email=address)
+            .get(mail=mailid.encode('ascii'), str_email=address)
 
     def set_msgrcpt_status(self, address, mailid, status):
         """Change the status (rs field) of a message recipient.

--- a/modoboa_amavis/views.py
+++ b/modoboa_amavis/views.py
@@ -139,7 +139,7 @@ def getmailcontent_selfservice(request, mail_id):
 
 @selfservice(getmailcontent_selfservice)
 def getmailcontent(request, mail_id):
-    mail = SQLemail(mail_id, dformat="plain")
+    mail = SQLemail(mail_id.encode('ascii'), dformat="plain")
     return render(request, "common/viewmail.html", {
         "headers": mail.render_headers(),
         "mailbody": mail.body
@@ -257,7 +257,7 @@ def release_selfservice(request, mail_id):
         raise BadRequest(_("Invalid request"))
     connector = SQLconnector()
     try:
-        msgrcpt = connector.get_recipient_message(rcpt, mail_id)
+        msgrcpt = connector.get_recipient_message(rcpt, mail_id.encode('ascii'))
     except Msgrcpt.DoesNotExist:
         raise BadRequest(_("Invalid request"))
     if secret_id != smart_text(msgrcpt.mail.secret_id):
@@ -310,6 +310,7 @@ def release(request, mail_id):
     for mid, rcpt in msgrcpts:
         # we can't use the .mail relation on rcpt because it leads to
         # an error on Postgres (memoryview pickle error).
+        mid = mid.encode('ascii')
         mail = Msgs.objects.get(pk=mid)
         result = amr.sendreq(mid, mail.secret_id, rcpt.rid.email)
         if result:


### PR DESCRIPTION
The delete functionality in qcleanup.py does not work if the mail_id is not defined as a 16 character BinaryField. The proper messages are identified, but the delete fails. There might be a simpler solution there, but I'm not familiar with Django.

Making the field a BinaryField breaks the web UI because the field is expected to be a string. So we have to encode the string to get the field types to match. I chose ASCII arbitrarily, it might not be the right answer. There are likely other places the mail_id field needs to be properly encoded, but the changes I have allow things to work as expected in my usage.

This fixes https://github.com/modoboa/modoboa-amavis/issues/135 (and probably https://github.com/modoboa/modoboa-amavis/issues/136)